### PR TITLE
#166258836 Share Profile Functionality

### DIFF
--- a/__tests__/components/ProfileImage.test.js
+++ b/__tests__/components/ProfileImage.test.js
@@ -1,14 +1,26 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { TouchableWithoutFeedback, Share } from 'react-native';
 import ProfileImage from '../../src/components/ProfileImage';
+
 const props = {
   imageUrl: 'fake url',
-  username: 'yves'
+  username: 'yves',
+  url: 'fake url'
 };
 
 describe('Profile image section', () => {
   it('should match the snapshot', () => {
     const wrapper = shallow(<ProfileImage profile={props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should share the profile ', async () => {
+    const share = jest.spyOn(Share, 'share');
+
+    const wrapper = shallow(<ProfileImage profile={props} />);
+    await wrapper.find(TouchableWithoutFeedback).simulate('press');
+    expect(share).toHaveBeenCalledTimes(1);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/components/ProfileImage.js
+++ b/src/components/ProfileImage.js
@@ -1,9 +1,33 @@
 import React, { Component } from 'react';
-import { Text, View, ImageBackground } from 'react-native';
+import {
+  Text,
+  View,
+  ImageBackground,
+  Share,
+  TouchableWithoutFeedback
+} from 'react-native';
 import { AntDesign } from '@expo/vector-icons';
 import styles from '../screens/ProfileStyleSheet';
 
 export default class ProfileImage extends Component {
+  constructor(props) {
+    super(props);
+  }
+  onShare = async () => {
+    const { username, url } = this.props;
+    try {
+      const result = await Share.share({
+        message: `Check out this awesome developer @${username}, ${url}`
+      });
+
+      if (result) {
+        alert('completed');
+      }
+    } catch (error) {
+      alert(error.message);
+    }
+  };
+
   render() {
     const { username, imageUrl } = this.props;
     return (
@@ -16,7 +40,9 @@ export default class ProfileImage extends Component {
             <Text style={styles.username}>@{username}</Text>
           </View>
           <View style={styles.shareIconContainer}>
-            <AntDesign size={45} color={'#fff'} name={'sharealt'} />
+            <TouchableWithoutFeedback onPress={this.onShare}>
+              <AntDesign size={45} color={'#fff'} name={'sharealt'} />
+            </TouchableWithoutFeedback>
           </View>
         </View>
       </ImageBackground>

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -62,7 +62,7 @@ export default class Profile extends Component {
     ) : (
       <View style={styles.container}>
         <StatusBar backgroundColor="blue" barStyle="light-content" />
-        <ProfileImage username={username} imageUrl={imageUrl} />
+        <ProfileImage username={username} imageUrl={imageUrl} url={gitHubUrl} />
         <View style={styles.aboutSection}>
           <Text style={styles.aboutTitle}>About</Text>
           <GithubLink fullName={fullName} username={username} />

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-
 import axios from 'axios';
 import { View, Text, ActivityIndicator, StatusBar } from 'react-native';
 import styles from './ProfileStyleSheet';
@@ -7,7 +6,6 @@ import ProfileImage from '../components/ProfileImage';
 import AboutItem from '../components/AboutSectionItem';
 import GithubLink from '../components/GithubLink';
 import NotFound from '../components/NotFound';
-
 export default class Profile extends Component {
   constructor() {
     super();


### PR DESCRIPTION
#### What does this PR do?
- Enable profile share functionality
#### Description of Task to be completed?
- Allow a user to share the link of the engineer's profile through communications platforms existing in a mobile device.  
#### How should this be manually tested?
- Clone the repo and check out `ft-share-profile-166258836 `
- Install all dependencies by `yarn`
- In project root directory run `yarn run test` to run tests. Tests should pass. 
- Run `yarn run start` to start the server 
- Follow the directions given, in the terminal. 
- You should see the list of engineers either in your simulator or your device.
- You should be able to see the profile screen when you click on one of the icons on the profile page
- On clicking the share icon, on the profile screen, a popup should display for sharing options available. And you can share the profile link. 
#### What are the relevant pivotal tracker stories?
#166258836

 #### Screenshots 
<a href="https://imgflip.com/gif/32vqog"><img src="https://i.imgflip.com/32vqog.gif" title="made at imgflip.com"/></a>