### PR TITLE
#166258838 Profile In-app Browser (view profile)

### DIFF
--- a/__tests__/screens/ProfileWebView.js
+++ b/__tests__/screens/ProfileWebView.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Profile from '../../src/screens/ProfileWebView';
+import { WebView } from 'react-native';
+
+const props = {
+  navigation: {
+    state: {
+      params: { url: 'fakeUrl' }
+    }
+  }
+};
+
+describe('profile screen', () => {
+  test('should render the profile screen using in app browser', () => {
+    const wrapper = shallow(<Profile {...props} />);
+    expect(wrapper.find(WebView)).toHaveLength(1);
+  });
+
+  test('should match snapshot', async () => {
+    const wrapper = shallow(<Profile {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/GithubLink.js
+++ b/src/components/GithubLink.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Text, View, TouchableHighlight } from 'react-native';
+import { Text, View, TouchableWithoutFeedback } from 'react-native';
 import styles from '../screens/ProfileStyleSheet';
 
 export default class GitHubLinKContainer extends Component {
@@ -16,13 +16,13 @@ export default class GitHubLinKContainer extends Component {
     return (
       <View style={styles.aboutSectionItems}>
         <Text style={styles.itemTitle}>GitHub Link</Text>
-        <TouchableHighlight onPress={this.openInWeb}>
+        <TouchableWithoutFeedback onPress={this.openInWeb}>
           <View style={styles.fullName}>
             <Text style={styles.itemText}>
               {fullName ? fullName : `@${username}`}
             </Text>
           </View>
-        </TouchableHighlight>
+        </TouchableWithoutFeedback>
       </View>
     );
   }

--- a/src/components/GithubLink.js
+++ b/src/components/GithubLink.js
@@ -3,14 +3,20 @@ import { Text, View, TouchableHighlight } from 'react-native';
 import styles from '../screens/ProfileStyleSheet';
 
 export default class GitHubLinKContainer extends Component {
+  constructor() {
+    super();
+  }
+  openInWeb = () => {
+    const { navigation, url } = this.props;
+    navigation.navigate('ProfileWebView', { url });
+  };
+
   render() {
     const { fullName, username } = this.props;
     return (
       <View style={styles.aboutSectionItems}>
         <Text style={styles.itemTitle}>GitHub Link</Text>
-        <TouchableHighlight
-          onPress={() => this.alert('Hey you clicked this guy')}
-        >
+        <TouchableHighlight onPress={this.openInWeb}>
           <View style={styles.fullName}>
             <Text style={styles.itemText}>
               {fullName ? fullName : `@${username}`}

--- a/src/navigation/Navigation.js
+++ b/src/navigation/Navigation.js
@@ -2,10 +2,11 @@ import React from 'react';
 import Home from '../screens/Home';
 import Profile from '../screens/ProfileScreen';
 import { createStackNavigator, createAppContainer } from 'react-navigation';
-
+import ProfileWebView from '../screens/ProfileWebView';
 const AppNavigator = createStackNavigator({
   Home: Home,
-  Profile: Profile
+  Profile: Profile,
+  ProfileWebView: ProfileWebView
 });
 
 const AppContainer = createAppContainer(AppNavigator);

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -54,6 +54,7 @@ export default class Profile extends Component {
       loading,
       error
     } = this.state;
+    const { navigation } = this.props;
 
     return loading ? (
       <View style={[styles.container, { justifyContent: 'center' }]}>
@@ -64,10 +65,15 @@ export default class Profile extends Component {
     ) : (
       <View style={styles.container}>
         <StatusBar backgroundColor="blue" barStyle="light-content" />
-        <ProfileImage username={username} imageUrl={imageUrl} />
+        <ProfileImage username={username} imageUrl={imageUrl} url={gitHubUrl} />
         <View style={styles.aboutSection}>
           <Text style={styles.aboutTitle}>About</Text>
-          <GithubLink fullName={fullName} username={username} />
+          <GithubLink
+            fullName={fullName}
+            username={username}
+            url={gitHubUrl}
+            navigation={navigation}
+          />
           <AboutItem item="repositories" amount={repositories} />
           <AboutItem item="stars" amount={stars} />
           <AboutItem item="followers" amount={followers} />

--- a/src/screens/ProfileWebView.js
+++ b/src/screens/ProfileWebView.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import { View, WebView } from 'react-native';
+
+export default class ProfileWebView extends Component {
+  render() {
+    const {
+      navigation: {
+        state: {
+          params: { url }
+        }
+      }
+    } = this.props;
+    return (
+      <View style={{ flex: 1 }}>
+        <WebView source={{ uri: url }} />
+      </View>
+    );
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
- Enable in-app browser to view GitHub profile
#### Description of Task to be completed?
- Allow a user to see the engineer's profile through the in-app browser.  
#### How should this be manually tested?
- Clone the repo and check out `ft-webview-profile-166258838`
- Install all dependencies by `yarn`
- In project root directory run `yarn run test` to run tests. Tests should pass. 
- Run `yarn run start` to start the server 
- Follow the directions given, in the terminal. 
- You should see the list of engineers either in your simulator or your device.
- You should be able to see the profile screen when you click on one of the icons on the profile page
- On clicking on the GitHub link, you should see the GitHub profile from GitHub.  
#### What are the relevant pivotal tracker stories?
#166258838


### screenshots
<a href="https://imgflip.com/gif/32whf0"><img src="https://i.imgflip.com/32whf0.gif" title="made at imgflip.com"/></a>